### PR TITLE
finish up rename of config flag for test and main

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,8 +186,8 @@ pub fn thread_dispatcher() -> impl Dispatcher {
     SimpleDispatcher { tx, _thread }
 }
 
-#[cfg(feature = "test-macro")]
+#[cfg(feature = "macros")]
 pub use async_dispatcher_macros::test;
 
-#[cfg(feature = "test-macro")]
+#[cfg(feature = "macros")]
 pub use async_dispatcher_macros::main;


### PR DESCRIPTION
These were missed in the rename to `macros` for the `main` and `test` helper macros.